### PR TITLE
Fix layout spacing across all screens

### DIFF
--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -55,11 +55,11 @@ function MainTabs() {
           fontSize: 12,
           fontWeight: '500',
         },
-        // Tab bar flush to bottom
+        // Tab bar with proper bottom spacing
         tabBarStyle: {
-          height: 50,
-          paddingTop: 0,
-          paddingBottom: 0,
+          height: 65,
+          paddingTop: 6,
+          paddingBottom: 12,
           backgroundColor: 'white',
           borderTopWidth: StyleSheet.hairlineWidth,
           borderTopColor: '#e5e7eb',

--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -99,8 +99,8 @@ export default function DashboardScreen({ navigation }: any) {
 
   return (
     <View style={styles.container}>
-      {/* Header with proper positioning */}
-      <View style={[styles.header, { paddingTop: Math.max(insets.top - 20, 10) }]}>
+      {/* Header with improved positioning - 1/4 inch lower */}
+      <View style={[styles.header, { paddingTop: Math.max(insets.top - 2, 28) }]}>
         <View style={styles.headerContent}>
           <View>
             <Text style={styles.greeting}>Welcome back, {currentUser?.name}!</Text>
@@ -113,10 +113,10 @@ export default function DashboardScreen({ navigation }: any) {
         </View>
       </View>
 
-      {/* Scroll area gets extra bottom padding so content clears the tab bar */}
+      {/* Scroll area with improved bottom spacing */}
       <ScrollView
         style={styles.container}
-        contentContainerStyle={{ paddingBottom: Math.max(insets.bottom, 4) + 75 }} // ~75 = tab bar height + spacing
+        contentContainerStyle={{ paddingBottom: Math.max(insets.bottom, 4) + 60 }} // Reduced from 75 to 60
         keyboardShouldPersistTaps="handled"
       >
         <View style={styles.statsGrid}>

--- a/src/screens/JobTrackerScreen.tsx
+++ b/src/screens/JobTrackerScreen.tsx
@@ -297,7 +297,7 @@ export default function JobTrackerScreen() {
   return (
     <>
     <View style={styles.container}>
-        <View style={[styles.header, { paddingTop: Math.max(insets.top - 30, 5) }]}>
+        <View style={[styles.header, { paddingTop: Math.max(insets.top - 12, 23) }]}>
           {isSelectionMode ? (
             <>
               <View style={styles.selectionHeader}>
@@ -666,7 +666,7 @@ const styles = StyleSheet.create({
   },
   fab: {
     position: 'absolute',
-    bottom: 37, // 1/4 inch lower (~18px down from 55)
+    bottom: 25, // Adjusted up from previous position
     right: 20,
     backgroundColor: COLORS.primary,
     width: 56,

--- a/src/screens/ResumeScreen.tsx
+++ b/src/screens/ResumeScreen.tsx
@@ -238,17 +238,18 @@ export default function ResumeScreen() {
 
   return (
     <View style={styles.container}>
+      {/* Header */}
+      <View style={[styles.header, { paddingTop: Math.max(insets.top - 2, 28) }]}>
+        <Text style={styles.title}>Resume Manager</Text>
+        <Text style={styles.subtitle}>Upload and tailor your resumes for specific jobs</Text>
+      </View>
+
       <ScrollView
         showsVerticalScrollIndicator={false}
         contentInsetAdjustmentBehavior="automatic"
         keyboardShouldPersistTaps="handled"
         contentContainerStyle={{ paddingBottom: 60 }}
       >
-        {/* Header */}
-        <View style={[styles.header, { paddingTop: Math.max(insets.top - 30, 5) }]}>
-          <Text style={styles.title}>Resume Manager</Text>
-          <Text style={styles.subtitle}>Upload and tailor your resumes for specific jobs</Text>
-        </View>
 
         {/* Primary Resume Section */}
         {primaryResume && (

--- a/src/screens/SignUpScreen.tsx
+++ b/src/screens/SignUpScreen.tsx
@@ -274,7 +274,7 @@ export default function SignUpScreen({ navigation }: any) {
         }}
         keyboardShouldPersistTaps="handled"
       >
-        <View style={[styles.header, { paddingTop: Math.max(insets.top - 30, 5) }]}>
+        <View style={[styles.header, { paddingTop: Math.max(insets.top - 12, 23) }]}>
             <Text style={styles.title}>Create Account</Text>
             <Text style={styles.subtitle}>Step {currentStep} of 4</Text>
             <View style={styles.progressBar}>

--- a/src/screens/TargetCompaniesScreen.tsx
+++ b/src/screens/TargetCompaniesScreen.tsx
@@ -351,7 +351,7 @@ export default function TargetCompaniesScreen() {
 
   return (
     <View style={styles.container}>
-      <View style={[styles.header, { paddingTop: Math.max(insets.top - 20, 10) }]}>
+      <View style={[styles.header, { paddingTop: Math.max(insets.top - 2, 28) }]}>
         <Text style={styles.title}>Target Companies</Text>
 
         {/* Header info */}
@@ -1005,7 +1005,7 @@ const styles = StyleSheet.create({
   },
   floatingButton: {
     position: 'absolute',
-    bottom: 37, // 1/4 inch lower (~18px down from 55)
+    bottom: 25, // Adjusted up from previous position
     right: 20,
     width: 56,
     height: 56,


### PR DESCRIPTION
Improved top and bottom spacing to prevent overlap with phone features:

## Header Spacing
- Adjusted header positioning to be 1/4 inch lower from phone status bar
- Updated formula from Math.max(insets.top - 30/20, 5/10) to Math.max(insets.top - 12/2, 23/28)
- Applied consistent spacing across Dashboard, JobTracker, Resume, TargetCompanies, and SignUp screens

## Bottom Spacing
- Reduced ScrollView bottom padding from 75 to 60 points in Dashboard
- Moved FAB buttons up from bottom: 37 to bottom: 25
- Fixed tab bar text cutoff by increasing height to 65 and adding bottom padding of 12

## Resume Screen Fix
- Restructured header to be outside ScrollView like other screens
- Now matches consistent spacing pattern used across the app

All screens now have proper spacing that avoids overlap with phone features.